### PR TITLE
blah

### DIFF
--- a/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
+++ b/app/src/main/java/com/eveningoutpost/dexdrip/NavDrawerBuilder.java
@@ -24,6 +24,12 @@ import com.eveningoutpost.dexdrip.utils.Preferences;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.DexcomShare;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.Disabled;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.Follower;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.NSFollow;
+import static com.eveningoutpost.dexdrip.utils.DexCollectionType.SHFollow;
+
 /**
  * Created by Emma Black on 11/5/14.
  */
@@ -102,15 +108,22 @@ public class NavDrawerBuilder {
                 this.nav_drawer_options.add(context.getString(R.string.start_sensor));
                 this.nav_drawer_intents.add(new Intent(context, StartNewSensor.class));
             }
-            else if (!Pref.getBooleanDefaultFalse("engineering_mode") && is_active_sensor) {
-                this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
-                this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
-            }
-            else {
-                this.nav_drawer_options.add(context.getString(R.string.start_sensor));
-                this.nav_drawer_intents.add(new Intent(context, StartNewSensor.class));
+
+            else if (!Pref.getBooleanDefaultFalse("engineering_mode")) {
+                if (!(DexCollectionType.getDexCollectionType().equals(Follower) || DexCollectionType.getDexCollectionType().equals(NSFollow) || DexCollectionType.getDexCollectionType().equals(SHFollow)
+                        || DexCollectionType.getDexCollectionType().equals(DexcomShare) || DexCollectionType.getDexCollectionType().equals(Disabled))) {
+
+                    if (is_active_sensor) {
+                        this.nav_drawer_options.add(context.getString(R.string.stop_sensor));
+                        this.nav_drawer_intents.add(new Intent(context, StopSensor.class));
+                    } else {
+                        this.nav_drawer_options.add(context.getString(R.string.start_sensor));
+                        this.nav_drawer_intents.add(new Intent(context, StartNewSensor.class));
+                    }
                 }
             }
+        }
+
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             if (DexCollectionType.hasBluetooth() && (DexCollectionType.getDexCollectionType() != DexCollectionType.DexcomG5)) {


### PR DESCRIPTION
Does not show Start/Stop Sensor options in the navigation bar for non-sensor collection methods. Allows both Start/Stop Sensor options to be shown simultaneously if engineering mode is enabled (kept from previous PR).